### PR TITLE
Fix path traversal vulnerability

### DIFF
--- a/tests/server.js
+++ b/tests/server.js
@@ -9,6 +9,12 @@ http.createServer(function(request, response) {
   var uri = url.parse(request.url).pathname
     , filename = path.join(process.cwd()+'/build', uri) ;
 
+  if (path.normalize(request.url) !== request.url) {
+    response.statusCode = 403;
+    response.end();
+    return;
+  }
+
   var contentTypesByExtension = {
     '.html': "text/html",
     '.css':  "text/css",


### PR DESCRIPTION
Due to incorrect usage of `path.join`, https://github.com/quantuminformation/test-recorder is vulnerable to Local File Inclusion vulnerability.
You can read more about this vulnerability and its side effects here: https://cwe.mitre.org/data/definitions/22.html

The vulnerable code is at ./tests/server.js file, which you can access online via: https://raw.githubusercontent.com/quantuminformation/test-recorder/HEAD/tests/server.js
If any of `path.join` arguments is a relative path to the parent directory (../), the returned path can be outside the intended directory and this might lead to leakage of sensitive files.


Running the project:
We used node command to run the file directly: `node ./tests/server.js`


Verified proof-of-concept(poc) to read passwd file(Path traversal vulnerability):
```bash
curl --path-as-is server_address:port/../../../../../../../../../../../../../../../../../../../etc/passwd
```

Denial of service vulnerability:
We also verified that this vulnerability can also lead to a Denial of Service attack, as it first loads the whole file content into memory, then tries to send the response.
Loading a large file (for example reading /dev/urandom/) can use all the memory within a few seconds and crash the server.

By default, running the vulnerable file opens a port in the network scope. Thus the Attack Vector (AV) of CVSS is: (N)etwork

Impact:
We've calculated the base score of the vulnerability as 9.1, with a severity of "Critical" using following the following vector_string: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H
You can view the CVSS score online via: https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H

Credits: Jafar Akhoundali and Hamidreza Hamidi


Fixes #45 